### PR TITLE
Fixed pandas import

### DIFF
--- a/mritc_demo.pipeline.py
+++ b/mritc_demo.pipeline.py
@@ -7,7 +7,6 @@ from shutil import copy2
 from typing import Any
 from uuid import uuid4
 
-import pandas as pd
 from ifdo.models import (
     ImageAcquisition,
     ImageCaptureMode,
@@ -315,6 +314,7 @@ class MRITCDemoPipeline(BasePipeline):
         config: dict[str, Any],  # noqa: ARG002
         **kwargs: dict,  # noqa: ARG002
     ) -> dict[Path, tuple[Path, ImageData | None, dict[str, Any] | None]]:
+        import pandas as pd
 
         # Initialise an empty dictionary to store file mappings
         data_mapping: dict[Path, tuple[Path, list[ImageData] | None, dict[str, Any] | None]] = {}


### PR DESCRIPTION
Moved the pandas import into the package step, as the pipeline is called before the dependencies are installed when collecting the collection and pipeline config. This breaks the pipeline with the current version of marimba, as pandas was removed as a marimba dependency.